### PR TITLE
Eliminate requirement to turn supershell off in sbt 1.3.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,5 @@ build.sbt
 
 ```scala
 enablePlugins(JShellPlugin)
-
-// if sbt 1.3.0 or higher
-ThisBuild / useSuperShell := false
 ```
+

--- a/src/main/scala/sbtjshell/JShellPlugin.scala
+++ b/src/main/scala/sbtjshell/JShellPlugin.scala
@@ -45,7 +45,9 @@ object JShellPlugin extends AutoPlugin {
               case _ =>
                 Nil
             }
-            runJShell(Seq("--class-path", path) ++ startup ++ args)
+            System.out.synchronized {
+              runJShell(Seq("--class-path", path) ++ startup ++ args)
+            }
           }
         }
       ).flatMap(_.flatten)


### PR DESCRIPTION
It seems you can protect interactive tasks from interference by supershell by embedding the interactivity in a block synchronized on `System.out`.

See https://github.com/sbt/sbt/issues/5122

...seems to work!
